### PR TITLE
Improve the project's setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,6 @@ project(CMake_GCov CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
 
-# Create OBJECT_DIR variable
-set(OBJECT_DIR ${CMAKE_BINARY_DIR}/CMakeFiles/RunAdder.dir)
-message("-- Object files will be output to: ${OBJECT_DIR}")
-
 # Set the sources
 set(SOURCES
     RunAdder.cpp
@@ -21,27 +17,41 @@ add_executable(RunAdder ${SOURCES})
 set_target_properties(RunAdder PROPERTIES COMPILE_FLAGS "--coverage")
 set_target_properties(RunAdder PROPERTIES LINK_FLAGS "--coverage")
 
-# Create the gcov target. Run coverage tests with 'make gcov'
-add_custom_target(gcov
+# Create the covr target. Run coverage tests with 'make covr'
+add_custom_target(covr
     COMMAND mkdir -p coverage
     COMMAND ${CMAKE_MAKE_PROGRAM} test
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
-add_custom_command(TARGET gcov
-    COMMAND echo "=================== GCOV ===================="
-    COMMAND gcov -b ${CMAKE_SOURCE_DIR}/*.cpp -o ${OBJECT_DIR}
-        | grep -A 5 "Adder.cpp" > CoverageSummary.tmp
-    COMMAND cat CoverageSummary.tmp
-    COMMAND echo "-- Coverage files have been output to ${CMAKE_BINARY_DIR}/coverage"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coverage  # Need separate command for this line
-    )
-add_dependencies(gcov RunAdder)
+
+add_custom_command(TARGET covr
+    COMMAND echo "=================== LCOV ===================="
+
+    COMMAND echo "Generating initial zero coverage..."
+        COMMAND lcov -c -i --directory ${CMAKE_BINARY_DIR}
+                        --output-file init_coverage.info --include **/*.cpp*
+
+    COMMAND echo "Generating base coverage..."
+        COMMAND lcov -c --directory ${CMAKE_BINARY_DIR}
+                        --output-file base_coverage.info --include **/*.cpp*
+
+    COMMAND echo "Generating combined coverage..."
+        COMMAND lcov -a init_coverage.info -a base_coverage.info
+                        -o coverage.info
+
+    COMMAND echo "Generating HTML report..."
+    COMMAND genhtml -o html coverage.info
+
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coverage
+)
+
+add_dependencies(covr RunAdder)
 # Make sure to clean up the coverage folder
 set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES coverage)
 
-# Create the gcov-clean target. This cleans the build as well as generated
+# Create the covr-clean target. This cleans the build as well as generated
 # .gcda and .gcno files.
-add_custom_target(scrub
+add_custom_target(covr-clean
     COMMAND ${CMAKE_MAKE_PROGRAM} clean
     COMMAND rm -f ${OBJECT_DIR}/*.gcno
     COMMAND rm -f ${OBJECT_DIR}/*.gcda

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ add_executable(RunAdder ${SOURCES})
 set_target_properties(RunAdder PROPERTIES COMPILE_FLAGS "--coverage")
 set_target_properties(RunAdder PROPERTIES LINK_FLAGS "--coverage")
 
-# Create the covr target. Run coverage tests with 'make covr'
+# Run tests and calculate coverage with the
+# 'camke --build <build_dir> --target covr' command.
 add_custom_target(covr
     COMMAND mkdir -p coverage
     COMMAND ${CMAKE_MAKE_PROGRAM} test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ add_custom_target(covr-clean
     )
 
 # Testing
-enable_testing()
+include(CTest)
 
 add_test(output_test ${CMAKE_CURRENT_BINARY_DIR}/RunAdder)
 set_tests_properties(output_test PROPERTIES PASS_REGULAR_EXPRESSION "0;5;10")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ add_dependencies(gcov RunAdder)
 # Make sure to clean up the coverage folder
 set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES coverage)
 
-# Create the gcov-clean target. This cleans the build as well as generated 
+# Create the gcov-clean target. This cleans the build as well as generated
 # .gcda and .gcno files.
 add_custom_target(scrub
     COMMAND ${CMAKE_MAKE_PROGRAM} clean

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(CMake_GCov CXX)
 
 # Set the compiler options
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_FLAGS "-g -O0 -Wall -fprofile-arcs -ftest-coverage")
 set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
 
 # Create OBJECT_DIR variable
@@ -18,6 +17,9 @@ set(SOURCES
 
 # Create the executable
 add_executable(RunAdder ${SOURCES})
+
+set_target_properties(RunAdder PROPERTIES COMPILE_FLAGS "--coverage")
+set_target_properties(RunAdder PROPERTIES LINK_FLAGS "--coverage")
 
 # Create the gcov target. Run coverage tests with 'make gcov'
 add_custom_target(gcov

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,34 +17,37 @@ add_executable(RunAdder ${SOURCES})
 set_target_properties(RunAdder PROPERTIES COMPILE_FLAGS "--coverage")
 set_target_properties(RunAdder PROPERTIES LINK_FLAGS "--coverage")
 
-# Run tests and calculate coverage with the
-# 'camke --build <build_dir> --target covr' command.
-add_custom_target(covr
-    COMMAND mkdir -p coverage
-    COMMAND ${CMAKE_MAKE_PROGRAM} test
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
+option(BUILD_TESTING "" ON)
+if(BUILD_TESTING)
+    # Run tests and calculate coverage with the
+    # 'camke --build <build_dir> --target covr' command.
+    add_custom_target(covr
+        COMMAND mkdir -p coverage
+        COMMAND ${CMAKE_MAKE_PROGRAM} test
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
 
-add_custom_command(TARGET covr
-    COMMAND echo "=================== LCOV ===================="
+    add_custom_command(TARGET covr
+        COMMAND echo "=================== LCOV ===================="
 
-    COMMAND echo "Generating initial zero coverage..."
+        COMMAND echo "Generating initial zero coverage..."
         COMMAND lcov -c -i --directory ${CMAKE_BINARY_DIR}
                         --output-file init_coverage.info --include **/*.cpp*
 
-    COMMAND echo "Generating base coverage..."
+        COMMAND echo "Generating base coverage..."
         COMMAND lcov -c --directory ${CMAKE_BINARY_DIR}
                         --output-file base_coverage.info --include **/*.cpp*
 
-    COMMAND echo "Generating combined coverage..."
+        COMMAND echo "Generating combined coverage..."
         COMMAND lcov -a init_coverage.info -a base_coverage.info
                         -o coverage.info
 
-    COMMAND echo "Generating HTML report..."
-    COMMAND genhtml -o html coverage.info
+        COMMAND echo "Generating HTML report..."
+        COMMAND genhtml -o html coverage.info
 
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coverage
-)
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coverage
+    )
+endif()
 
 add_dependencies(covr RunAdder)
 # Make sure to clean up the coverage folder
@@ -60,7 +63,10 @@ add_custom_target(covr-clean
     )
 
 # Testing
-include(CTest)
+if(BUILD_TESTING)
+    include(CTest)
 
-add_test(output_test ${CMAKE_CURRENT_BINARY_DIR}/RunAdder)
-set_tests_properties(output_test PROPERTIES PASS_REGULAR_EXPRESSION "0;5;10")
+    add_test(output_test ${CMAKE_CURRENT_BINARY_DIR}/RunAdder)
+    set_tests_properties(
+        output_test PROPERTIES PASS_REGULAR_EXPRESSION "0;5;10")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ if(BUILD_TESTING)
     # 'camke --build <build_dir> --target covr' command.
     add_custom_target(covr
         COMMAND mkdir -p coverage
-        COMMAND ${CMAKE_MAKE_PROGRAM} test
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
 


### PR DESCRIPTION
* Split `covr` and `test` targets
* Introduce test build switch
* Include CTest instead of enabling tests
* Improve `covr` target's comment
* Switch to LCOV and generate a nice html report
* Use `--coverage` compiler flag on the target
* Remove trailing spaces
